### PR TITLE
fix(bench): the guard from #58 could not fail, and its acceptance test always skipped (#65)

### DIFF
--- a/qwen38-tuning/bench/tests/test_chat_template_travels.py
+++ b/qwen38-tuning/bench/tests/test_chat_template_travels.py
@@ -145,6 +145,103 @@ def test_the_profile_refuses_a_launch_that_lost_the_flag():
     assert m, "nothing refuses a launch whose final argv lost the template"
 
 
+# ------------------------------------------- the guard, made dirty on purpose
+
+STOCK = os.path.join(ROOT, "qwen38-tuning", "templates", "qwen38-stock.jinja")
+
+
+def test_the_guard_actually_fires_when_the_flag_is_gone():
+    """A positive control, because the test beside it cannot fail (issue #65).
+
+    `test_the_profile_refuses_a_launch_that_lost_the_flag` greps the SOURCE for
+    the guard. It would pass if the guard's body were `Write-Host "hello"`, and
+    with the shipped code the branch is unreachable -- $argv always carries the
+    flag unless -StockTemplate is passed. So the guard that is supposed to stop
+    a third recurrence had never been observed to fire.
+
+    This makes the detector dirty: a copy of the profile with $templateArg
+    removed from the argv assembly, run for real. The copy lives BESIDE the
+    original because the profile resolves paths from $PSScriptRoot, and a copy
+    in a temp directory would fail on something else long before reaching the
+    guard -- which would look like a pass.
+    """
+    src = io.open(PROFILE, encoding="utf-8", errors="replace").read()
+    broken_src = src.replace("+ $thinkArg + $templateArg + @(",
+                             "+ $thinkArg + @(")
+    assert broken_src != src, "the argv assembly changed shape; update this test"
+
+    broken = os.path.join(os.path.dirname(PROFILE), "_guard-positive-control.ps1")
+    try:
+        io.open(broken, "w", encoding="utf-8", newline="").write(broken_src)
+        r = subprocess.run(
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", broken, "-WhatIf", "-Nvfp4", "-Vision"],
+            capture_output=True, text=True, timeout=180)
+        out = r.stdout + r.stderr
+    finally:
+        if os.path.exists(broken):
+            os.remove(broken)
+
+    assert r.returncode != 0, ("the guard did not refuse a launch that lost the "
+                               "flag", out)
+    assert "lost --chat-template-file" in out, out
+    # It must REFUSE, not preview. The first version of this line searched for
+    # the flag after the string "would run" -- which is absent when the guard
+    # fires, so `split` returned the whole output and matched the FATAL's own
+    # text. Assert on the preview banner itself; it is the thing that must not
+    # be there.
+    assert "WhatIf: would run" not in out, (
+        "it previewed the broken command line instead of refusing", out)
+
+
+def test_the_guard_prints_what_it_actually_built():
+    """Exiting without showing the argv leaves whoever hits it with nothing to
+    read. The other FATAL in this profile previews deliberately; this one must
+    not, so it owes the reader the array instead.
+
+    The region is cut at the guard's own `exit 1`, not by a character count.
+    The first version took `src[i:i+1200]`, which ran past the guard into the
+    `-WhatIf` block below it -- and that block prints `$argv`, so the assertion
+    passed while reading the wrong code. That is the leak this file's own
+    workflow warns about, in the test written to catch a leak.
+
+    And it asserts on a Write-Host, not on the token `$argv` -- which appears in
+    the guard's own CONDITION, so the looser version passed on the code that
+    tests whether the flag is missing rather than on any code that shows it.
+    Twice in one function, the assertion read something adjacent to its subject.
+    """
+    src = io.open(PROFILE, encoding="utf-8", errors="replace").read()
+    start = src.index("if (-not $StockTemplate")
+    body = src[src.index("{", start):src.index("exit 1", start)]
+    assert re.search(r"Write-Host[^\n]*\$argv", body), (
+        "the guard exits without printing the argv it built", body)
+
+
+# --------------------------------- the stock template, vendored so this is offline
+
+def test_the_stock_template_is_vendored():
+    """#58 asked for the one-line difference to be verified by a test rather
+    than by hand. The /props version of that check skips whenever a normal
+    profile is serving -- which is almost always -- so the criterion was written
+    and never exercised. A checked-in copy of the artifact's own template makes
+    it an offline assertion that runs every time."""
+    assert os.path.isfile(STOCK), STOCK
+    body = io.open(STOCK, encoding="utf-8", errors="replace").read()
+    assert RAISE in body, "the vendored copy is not the STOCK template"
+
+
+def test_ours_differs_from_the_vendored_stock_by_exactly_one_line():
+    a = io.open(STOCK, encoding="utf-8", errors="replace").read()
+    b = io.open(TEMPLATE, encoding="utf-8", errors="replace").read()
+    a = a.replace("\r\n", "\n").rstrip("\n").split("\n")
+    b = b.replace("\r\n", "\n").rstrip("\n").split("\n")
+    assert len(a) == len(b), ("different shapes; re-derive per templates/README.md",
+                              len(a), len(b))
+    differing = [i for i, (x, y) in enumerate(zip(a, b), 1) if x != y]
+    assert len(differing) == 1, ("exactly one line may differ", differing)
+    assert RAISE in a[differing[0] - 1], a[differing[0] - 1]
+
+
 # ------------------------------------------------------------ the file itself
 
 def test_the_template_exists_and_is_the_patched_one():

--- a/qwen38-tuning/scripts/worker-q4-dual.ps1
+++ b/qwen38-tuning/scripts/worker-q4-dual.ps1
@@ -412,18 +412,14 @@ param(
     [int]$SsePingIntervalSec = 5,
     # Serve the artifact's OWN chat template, without our one-line patch.
     #
-    # The patch (templates/qwen38-late-system.jinja, issue #4) renders a system
-    # message that arrives after the user turn instead of raising on it. Claude
-    # Code sends exactly that -- its SessionStart hook output is a role:"system"
-    # message of 25-33 KB appended after the user turn -- so without the patch
-    # every request comes back HTTP 500, `System message must be at the
-    # beginning.`
+    # WHY THE REASON IS NOT WRITTEN HERE: it was, in three places -- this header,
+    # serve.ps1's, and templates/README.md -- and a rationale in three places
+    # drifts the moment one is edited. This repository already corrected that
+    # exact shape once (2649f4e). The README is the one copy; issue #65.
     #
-    # Unsloth Studio passes no template file, so `-Beta` and `-Clone` used to
-    # drop it as part of borrowing their command line. That is what this switch
-    # is for now: the omission is still reachable, but it has to be ASKED FOR.
-    # Choosing a thinking mechanism must not decide it -- see issue #58, and
-    # CORRECTIONS 36 for the first time -Beta silently dropped a flag.
+    # In one line: without the patched template every Claude Code request comes
+    # back HTTP 500. Unsloth Studio omits it safely because their client never
+    # sends a system message after the user turn, and ours does.
     [switch]$StockTemplate,
     # Micro-batch. A parameter rather than a literal because the budget check
     # below needs it: the compute buffer is about one -ub of MiB per card.
@@ -1478,12 +1474,25 @@ if ($Clone) {
 # reads the FINAL argv, so a branch written later -- $Clone rebuilds it from
 # scratch, and nothing stops another from doing the same -- fails loudly here
 # instead of serving HTTP 500 to every request until somebody reads a log.
+#
+# IT DOES NOT PREVIEW UNDER -WhatIf, AND THE OTHER FATAL IN THIS FILE DOES.
+# That difference is deliberate and it is the only reason this comment exists,
+# because from the code the two look like one of them is an oversight (#65).
+# The `-ts` budget FATAL reports the ENVIRONMENT -- busy cards, true this minute
+# and false the next -- so previewing anyway is useful and a test depends on it.
+# This one reports a CODING DEFECT: an argv that lost a flag is never fine, and
+# a preview of a command line nobody may run is not worth printing. What it owes
+# the reader instead is the array it actually built, so the defect is diagnosable
+# from the refusal alone.
 if (-not $StockTemplate -and ($argv -notcontains '--chat-template-file')) {
     Write-Host "FATAL: the command line lost --chat-template-file." -ForegroundColor Red
     Write-Host "  Without it Qwen3.8's own template RAISES on a system message that" -ForegroundColor Yellow
     Write-Host "  arrives after the user turn, which is what Claude Code sends, and" -ForegroundColor Yellow
     Write-Host "  every request returns HTTP 500. See issue #58 and #4." -ForegroundColor Yellow
     Write-Host "  Pass -StockTemplate if the omission is what you meant." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "  what was actually built:" -ForegroundColor Yellow
+    Write-Host "    $Exe $($argv -join ' ')"
     exit 1
 }
 

--- a/qwen38-tuning/templates/README.md
+++ b/qwen38-tuning/templates/README.md
@@ -58,6 +58,30 @@ now lives on its own switch, `-StockTemplate`, and the profile refuses to launch
 when the final `argv` lost the flag any other way. See CORRECTIONS 43 and
 issue #58.
 
+## `qwen38-stock.jinja` — the artifact's own template, unmodified
+
+Added 2026-08-31, issue #65. It is the second file in this folder and it exists
+so the one-line claim above can be **checked offline, every test run**.
+
+Issue #58 asked for that difference to be *"verified in a test, not by hand"*,
+and the test written for it read `/props` from a live server. **`/props` reports
+the template the server is USING** — so a normally-booted profile hands back our
+own patched file, and the check can only run against a boot with
+`-StockTemplate`, which had never happened. **The criterion was written and never
+exercised.** It passed once, against a `-Beta` boot that happened to have no
+override, and then reported *zero* differing lines as if the patch had vanished.
+
+With the stock text checked in, `test_ours_differs_from_the_vendored_stock_by_exactly_one_line`
+runs with no server at all. The `/props` comparison stays as the stronger form
+when a `-StockTemplate` boot is available — it is the only thing that can catch
+**this file** drifting from the artifact.
+
+**Provenance:** extracted from `GET /props` on 2026-08-31 while
+`serve-20260831-023636.log` was serving `Qwen3.8-27B-NVFP4-MTP-VERY-LOW` with no
+`--chat-template-file` on its command line, so `/props` was reporting the GGUF's
+own text. 183 lines; it differs from `qwen38-late-system.jinja` at line 110 and
+nowhere else.
+
 ## Regenerating it
 
 The template belongs to the model, so it must be re-derived if the artifact changes.

--- a/qwen38-tuning/templates/qwen38-stock.jinja
+++ b/qwen38-tuning/templates/qwen38-stock.jinja
@@ -1,0 +1,184 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set sysns = namespace(count=0, text='') %}
+{%- for message in messages %}
+    {%- if sysns.count == loop.index0 and (message.role == 'system' or message.role == 'developer') %}
+        {%- set sys_content = render_content(message.content, false, true)|trim %}
+        {%- if sys_content %}
+            {%- set sysns.text = sysns.text + ('\n' if sysns.text else '') + sys_content %}
+        {%- endif %}
+        {%- set sysns.count = sysns.count + 1 %}
+    {%- endif %}
+{%- endfor %}
+{%- set num_sys = sysns.count %}
+{%- set merged_system = sysns.text %}
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {%- if resolved_reasoning_effort == 'high' %}
+        {%- set resolved_reasoning_effort = 'xhigh' %}
+    {%- endif %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+    {%- if resolved_reasoning_effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if merged_system %}
+        {{- '\n\n' + merged_system }}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if merged_system %}
+        {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '')  + merged_system + '<|im_end|>\n' }}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if loop.index0 >= num_sys %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" or message.role == "developer" %}
+        {{- raise_exception('System message must be at the beginning.') }}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if preserve_thinking is undefined or preserve_thinking is true or loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if tool_call.name is not defined or tool_call.name is none %}
+                    {{- raise_exception('Tool call is missing a function name.') }}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is mapping %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- elif tool_call.arguments is string %}
+                    {%- if tool_call.arguments|trim %}
+                        {{- raise_exception('Tool call arguments for function "' + (tool_call.name | string) + '" were passed as a JSON string. Parse them into an object before calling apply_chat_template.') }}
+                    {%- endif %}
+                {%- elif tool_call.arguments is defined and tool_call.arguments is not none %}
+                    {{- raise_exception('Tool call arguments for function "' + (tool_call.name | string) + '" must be an object/mapping or a JSON string.') }}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}
+{#- Unsloth fixes - developer role, merged system messages, tool calling #}

--- a/serve.ps1
+++ b/serve.ps1
@@ -129,9 +129,10 @@ param(
     [switch]$TheirMirror,
     [switch]$TheirBuild,
     # Serve the artifact's own chat template rather than our one-line patch.
-    # The patch is what keeps Claude Code from getting HTTP 500 on every
-    # request; Unsloth Studio omits it safely because their client never sends
-    # a system message after the user turn. Issue #58.
+    # Without the patch every Claude Code request comes back HTTP 500.
+    # The reason lives in qwen38-tuning/templates/README.md and only there --
+    # it used to be written out in three places, which is how a rationale
+    # drifts. Issues #58 and #65.
     [switch]$StockTemplate,
     [switch]$MaxCtx,
     [switch]$Mtp,


### PR DESCRIPTION
Fixes every finding from the post-hoc `/code-review` on `689c705...HEAD`.

- `ea5db06` fix(bench): the guard from #58 could not fail, and its acceptance test always skipped (#65)

The guard added by #58 now has a **positive control** — a copy of the profile with `\` removed, run for real — because its previous test grepped the source and would have passed on `Write-Host "hello"`. The one-line template check runs **offline** against a vendored `qwen38-stock.jinja` instead of a `/props` read that skipped every time. The two FATALs with opposite `-WhatIf` meanings now say why, and the rationale is in one file instead of three.

Three of my own assertions read something adjacent to their subject while writing this; each was caught by running it and each is described in the commit.

Written red first: 4 failed, then green. 1,438 -> 1,442 passed, 3 skipped. 567 doc links, 0 broken. Auditor exit 0.

Closes #65

---

แก้ทุกข้อที่เจอจาก `/code-review` ที่รันย้อนหลังบน `689c705...HEAD`

ด่านที่ #58 เพิ่มเข้ามาตอนนี้มี **positive control** แล้ว — ก๊อปโปรไฟล์ที่ลบ `\` ออกแล้วรันจริง — เพราะ test เดิมของมัน grep source code และจะผ่านเหมือนเดิมต่อให้เนื้อในเป็น `Write-Host "hello"` · การตรวจความต่างบรรทัดเดียวรัน **ออฟไลน์** เทียบกับ `qwen38-stock.jinja` ที่เก็บไว้ แทนที่จะอ่าน `/props` ซึ่ง skip ทุกครั้ง · FATAL สองตัวที่มีความหมาย `-WhatIf` ตรงข้ามกันตอนนี้บอกเหตุผลแล้ว และเหตุผลอยู่ไฟล์เดียวแทนที่จะเป็นสามไฟล์

มี assertion ของผมเองสามข้อที่อ่านของข้าง ๆ แทนที่จะอ่านตัวที่ตั้งใจตรวจ ทุกข้อจับได้ด้วยการรันจริง และเขียนไว้ครบใน commit

เขียนแดงก่อน 4 ตก แล้วเขียว · 1,438 -> 1,442 ผ่าน skip 3 · ลิงก์ 567 พัง 0 · auditor exit 0